### PR TITLE
Fix converter crash, extend save file support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -75,3 +75,5 @@
 2024-10-10 working on reading/saving ccx core data into .cub
 2024-10-11 working on reading/saving ccx core data into .cub
 2024-10-12 bug fix crash vtk writer in parallel
+2024-10-12 working on reading/saving ccx core data into .cub
+

--- a/changelog.txt
+++ b/changelog.txt
@@ -73,3 +73,4 @@
 2024-10-05 found autocleanup issue on windows
 2024-10-07 fixed autocleanup issue on windows
 2024-10-10 working on reading/saving ccx core data into .cub
+2024-10-11 working on reading/saving ccx core data into .cub

--- a/changelog.txt
+++ b/changelog.txt
@@ -74,3 +74,4 @@
 2024-10-07 fixed autocleanup issue on windows
 2024-10-10 working on reading/saving ccx core data into .cub
 2024-10-11 working on reading/saving ccx core data into .cub
+2024-10-12 bug fix crash vtk writer in parallel

--- a/changelog.txt
+++ b/changelog.txt
@@ -72,3 +72,4 @@
 2024-10-05 working on reading/saving ccx core data into .cub
 2024-10-05 found autocleanup issue on windows
 2024-10-07 fixed autocleanup issue on windows
+2024-10-10 working on reading/saving ccx core data into .cub

--- a/examples/bolted_connection/bolted_connection.jou
+++ b/examples/bolted_connection/bolted_connection.jou
@@ -31,10 +31,10 @@ block 2 add vol 2
 block 3 add vol 3 to 5
 #block all element type hex20
 
-nodeset 1 add surface 4  
-nodeset 1 name "plate_1"
-nodeset 2 add surface 12  
-nodeset 2 name "plate_2"
+#nodeset 1 add surface 4  
+#nodeset 1 name "plate_1"
+#nodeset 2 add surface 12  
+#nodeset 2 name "plate_2"
 
 sideset 1 add surface 30  
 sideset 1 name "plate_1_top"
@@ -85,10 +85,10 @@ ccx modify temperature 2 keyword_type temp
 ccx modify temperature 1 keyword_type temp
 
 # plate bc
-create displacement name "plate_1_fix" on nodeset 1 dof 1 dof 2 dof 3 fix 0
-create displacement name "plate_2_fix" on nodeset 2 dof 1 dof 2 dof 3 fix 0
-create displacement name "plate_1_pull" on nodeset 1 dof 1 fix -0.35
-create displacement name "plate_2_pull" on nodeset 2 dof 1 fix 0.35
+create displacement name "plate_1_fix" on surface 4 dof 1 dof 2 dof 3 fix 0
+create displacement name "plate_2_fix" on surface 12 dof 1 dof 2 dof 3 fix 0
+create displacement name "plate_1_pull" on surface 4 dof 1 fix -0.35
+create displacement name "plate_2_pull" on surface 12 dof 1 fix 0.35
 
 ccx create historyoutput name "ho_1" element
 ccx modify historyoutput 1 element block 1 totals_yes
@@ -146,7 +146,3 @@ ccx create job name "bolted_connection"
 #ccx result load job 1
 #ccx use logfile core on
 #ccx result convert job 1 partial block 1 2 3
-
-
-
-

--- a/src/CalculiXComp.cpp
+++ b/src/CalculiXComp.cpp
@@ -216,6 +216,8 @@ void CalculiXComp::restore_settings()
   ccx_uo.mPathIconsName = "Path to Icons";
   config.read_entry("PathPythonInterface", ccx_uo.mPathPythonInterface);
   ccx_uo.mPathPythonInterfaceName = "Path to Python Interface";
+  config.read_bool_entry("SaveLoadedResults", ccx_uo.mSaveLoadedResults);
+  ccx_uo.mSaveLoadedResultsName = "Save loaded FRD and DAT data";
 }
 
 void CalculiXComp::save_settings()
@@ -230,6 +232,7 @@ void CalculiXComp::save_settings()
   config.write_entry("PathParaView", ccx_uo.mPathParaView);
   config.write_entry("PathIcons", ccx_uo.mPathIcons);
   config.write_entry("PathPythonInterface", ccx_uo.mPathPythonInterface);
+  config.write_bool_entry("SaveLoadedResults", ccx_uo.mSaveLoadedResults);
 }
 
 void CalculiXComp::load_options()

--- a/src/Core/CalculiXCore.cpp
+++ b/src/Core/CalculiXCore.cpp
@@ -547,6 +547,191 @@ bool CalculiXCore::read_cub(std::string filename)
     {
       results->create_frd_dat(results->results_data[i][1]);
     }
+    for (size_t i = 0; i < results->frd_data.size(); i++)
+    {
+      int job_id = results->frd_data[i].job_id;
+      std::string group = "Cubit-CalculiX/Results/Frd/" + std::to_string(job_id) + "/";
+      std::string subgroup = group;
+        
+      if (cubTool.nameExists(group.c_str()))
+      {
+        cubTool.read_dataset_string_rank_2("header",group.c_str(), results->frd_data[i].header);
+        cubTool.read_dataset_string_rank_2("materials",group.c_str(), results->frd_data[i].materials);
+        cubTool.read_dataset_int_rank_2("nodes",group.c_str(), results->frd_data[i].nodes);
+        cubTool.read_dataset_double_rank_2("nodes_coords",group.c_str(), results->frd_data[i].nodes_coords);
+        cubTool.read_dataset_int_rank_2("elements",group.c_str(), results->frd_data[i].elements);
+        cubTool.read_dataset_int_rank_2("elements_connectivity",group.c_str(), results->frd_data[i].elements_connectivity);
+        cubTool.read_dataset_int_rank_2("result_blocks",group.c_str(), results->frd_data[i].result_blocks);
+        cubTool.read_dataset_double_rank_1("total_times",group.c_str(), results->frd_data[i].total_times);
+        
+        subgroup = group + "result_block_components/";
+        if (cubTool.nameExists(subgroup.c_str()))
+        {
+          int ii = 0;
+          subgroup = group + "result_block_components/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "result_block_components/";
+            std::vector<std::string> tmp;
+            results->frd_data[i].result_block_components.push_back(tmp);
+            cubTool.read_dataset_string_rank_1(dataset.c_str(),subgroup.c_str(), results->frd_data[i].result_block_components[ii]);
+            ++ii;
+            subgroup = group + "result_block_components/" + std::to_string(ii) +"/";
+          }
+        }
+        cubTool.read_dataset_string_rank_1("result_block_type",group.c_str(), results->frd_data[i].result_block_type);
+        subgroup = group + "result_block_data/";
+        if (cubTool.nameExists(subgroup.c_str()))
+        {
+          int ii = 0;
+          subgroup = group + "result_block_data/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "result_block_data/";
+            std::vector<std::vector<double>> tmp;
+            results->frd_data[i].result_block_data.push_back(tmp);
+            cubTool.read_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->frd_data[i].result_block_data[ii]);
+            ++ii;
+            subgroup = group + "result_block_data/" + std::to_string(ii) +"/";
+          }
+        }
+        subgroup = group + "result_block_node_data/";
+        if (cubTool.nameExists(subgroup.c_str()))
+        {
+          int ii = 0;
+          subgroup = group + "result_block_node_data/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "result_block_node_data/";
+            std::vector<std::vector<int>> tmp;
+            results->frd_data[i].result_block_node_data.push_back(tmp);
+            cubTool.read_dataset_int_rank_2(dataset.c_str(),subgroup.c_str(), results->frd_data[i].result_block_node_data[ii]);
+            ++ii;
+            subgroup = group + "result_block_node_data/" + std::to_string(ii) +"/";
+          }
+        }
+        cubTool.read_dataset_int_rank_1("sorted_node_ids",group.c_str(), results->frd_data[i].sorted_node_ids);
+        cubTool.read_dataset_int_rank_1("sorted_node_data_ids",group.c_str(), results->frd_data[i].sorted_node_data_ids);
+        subgroup = group + "sorted_result_node_ids/";
+        if (cubTool.nameExists(subgroup.c_str()))
+        {
+          int ii = 0;
+          subgroup = group + "sorted_result_node_ids/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "sorted_result_node_ids/";
+            std::vector<int> tmp;
+            results->frd_data[i].sorted_result_node_ids.push_back(tmp);
+            cubTool.read_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->frd_data[i].sorted_result_node_ids[ii]);
+            ++ii;
+            subgroup = group + "sorted_result_node_ids/" + std::to_string(ii) +"/";
+          }
+        }
+        subgroup = group + "sorted_result_node_ids/";
+        if (cubTool.nameExists(subgroup.c_str()))
+        {
+          int ii = 0;
+          subgroup = group + "sorted_result_node_data_ids/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "sorted_result_node_data_ids/";
+            std::vector<int> tmp;
+            results->frd_data[i].sorted_result_node_data_ids.push_back(tmp);
+            cubTool.read_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->frd_data[i].sorted_result_node_data_ids[ii]);
+            ++ii;
+            subgroup = group + "sorted_result_node_data_ids/" + std::to_string(ii) +"/";
+          }
+        }        
+      }
+    }
+/*
+    for (size_t i = 0; i < results->dat_data.size(); i++)
+    {
+      int job_id = results->dat_data[i].job_id;
+      std::string group = "Cubit-CalculiX/Results/Dat/" + std::to_string(job_id) + "/";
+      cubTool.createGroup(group.c_str());
+      cubTool.write_dataset_int_rank_2("result_blocks",group.c_str(), results->dat_data[i].result_blocks);
+      cubTool.write_dataset_double_rank_1("total_times",group.c_str(), results->dat_data[i].total_times);
+      if (results->dat_data[i].result_block_components.size()>0)
+      {
+        std::string subgroup = group + "result_block_components/";
+        cubTool.createGroup(subgroup.c_str());
+        for (size_t ii = 0; ii < results->dat_data[i].result_block_components.size(); ii++)
+        {
+          std::string dataset = std::to_string(ii);
+          cubTool.write_dataset_string_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_components[ii]);
+        }
+      }
+      cubTool.write_dataset_string_rank_1("result_block_type",group.c_str(), results->dat_data[i].result_block_type);
+      cubTool.write_dataset_string_rank_1("result_block_set",group.c_str(), results->dat_data[i].result_block_set);
+      if (results->dat_data[i].result_block_data.size()>0)
+      {
+        std::string subgroup = group + "result_block_data/";
+        cubTool.createGroup(subgroup.c_str());
+        for (size_t ii = 0; ii < results->dat_data[i].result_block_data.size(); ii++)
+        {
+          std::string dataset = std::to_string(ii);
+          cubTool.write_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_data[ii]);
+        }
+      }
+      if (results->dat_data[i].result_block_data.size()>0)
+      {
+        std::string subgroup = group + "result_block_c1_data/";
+        cubTool.createGroup(subgroup.c_str());
+        for (size_t ii = 0; ii < results->dat_data[i].result_block_c1_data.size(); ii++)
+        {
+          std::string dataset = std::to_string(ii);
+          cubTool.write_dataset_int_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_c1_data[ii]);
+        }
+      }
+      if (results->dat_data[i].buckle_data.size()>0)
+      {
+        std::string subgroup = group + "buckle_data/";
+        cubTool.createGroup(subgroup.c_str());
+        for (size_t ii = 0; ii < results->dat_data[i].buckle_data.size(); ii++)
+        {
+          std::string dataset = std::to_string(ii);
+          cubTool.write_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].buckle_data[ii]);
+        }
+      }
+      if (results->dat_data[i].sorted_c1.size()>0)
+      {
+        std::string subgroup = group + "sorted_c1/";
+        cubTool.createGroup(subgroup.c_str());
+        for (size_t ii = 0; ii < results->dat_data[i].sorted_c1.size(); ii++)
+        {
+          std::string dataset = std::to_string(ii);
+          cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_c1[ii]);
+        }
+      }
+      if (results->dat_data[i].sorted_c1.size()>0)
+      {
+        std::string subgroup = group + "sorted_result_block_c1_data_id/";
+        cubTool.createGroup(subgroup.c_str());
+        for (size_t ii = 0; ii < results->dat_data[i].sorted_result_block_c1_data_id.size(); ii++)
+        {
+          std::string dataset = std::to_string(ii);
+          cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_id[ii]);
+        }
+      }
+      if (results->dat_data[i].sorted_c1.size()>0)
+      {
+        std::string subgroup = group + "sorted_result_block_c1_data_type/";
+        cubTool.createGroup(subgroup.c_str());
+        for (size_t ii = 0; ii < results->dat_data[i].sorted_result_block_c1_data_type.size(); ii++)
+        {
+          std::string dataset = std::to_string(ii);
+          cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_type[ii]);
+        }
+      }
+    }
+*/
+
     //CustomLines
     cubTool.read_dataset_string_rank_2("customlines_data","Cubit-CalculiX/CustomLines", customlines->customlines_data);
     
@@ -734,33 +919,139 @@ bool CalculiXCore::save_cub(std::string filename)
         cubTool.write_dataset_int_rank_2("elements_connectivity",group.c_str(), results->frd_data[i].elements_connectivity);
         cubTool.write_dataset_int_rank_2("result_blocks",group.c_str(), results->frd_data[i].result_blocks);
         cubTool.write_dataset_double_rank_1("total_times",group.c_str(), results->frd_data[i].total_times);
-        cubTool.write_dataset_string_rank_2("result_block_components",group.c_str(), results->frd_data[i].result_block_components);
+        if (results->frd_data[i].result_block_components.size()>0)
+        {
+          std::string subgroup = group + "result_block_components/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->frd_data[i].result_block_components.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_string_rank_1(dataset.c_str(),subgroup.c_str(), results->frd_data[i].result_block_components[ii]);
+          }
+        }
         cubTool.write_dataset_string_rank_1("result_block_type",group.c_str(), results->frd_data[i].result_block_type);
-        cubTool.write_dataset_double_rank_3("result_block_data",group.c_str(), results->frd_data[i].result_block_data);
-        cubTool.write_dataset_int_rank_3("result_block_node_data",group.c_str(), results->frd_data[i].result_block_node_data);
+        if (results->frd_data[i].result_block_data.size()>0)
+        {
+          std::string subgroup = group + "result_block_data/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->frd_data[i].result_block_data.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->frd_data[i].result_block_data[ii]);
+          }
+        }
+        if (results->frd_data[i].result_block_node_data.size()>0)
+        {
+          std::string subgroup = group + "result_block_node_data/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->frd_data[i].result_block_node_data.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_int_rank_2(dataset.c_str(),subgroup.c_str(), results->frd_data[i].result_block_node_data[ii]);
+          }
+        }
         cubTool.write_dataset_int_rank_1("sorted_node_ids",group.c_str(), results->frd_data[i].sorted_node_ids);
         cubTool.write_dataset_int_rank_1("sorted_node_data_ids",group.c_str(), results->frd_data[i].sorted_node_data_ids);
-        cubTool.write_dataset_int_rank_2("sorted_result_node_ids",group.c_str(), results->frd_data[i].sorted_result_node_ids);
-        cubTool.write_dataset_int_rank_2("sorted_result_node_data_ids",group.c_str(), results->frd_data[i].sorted_result_node_data_ids);
+        if (results->frd_data[i].sorted_result_node_ids.size()>0)
+        {
+          std::string subgroup = group + "sorted_result_node_ids/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->frd_data[i].sorted_result_node_ids.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->frd_data[i].sorted_result_node_ids[ii]);
+          }
+        }
+        if (results->frd_data[i].sorted_result_node_ids.size()>0)
+        {
+          std::string subgroup = group + "sorted_result_node_data_ids/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->frd_data[i].sorted_result_node_data_ids.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->frd_data[i].sorted_result_node_data_ids[ii]);
+          }
+        }
       }
       for (size_t i = 0; i < results->dat_data.size(); i++)
       {
         int job_id = results->dat_data[i].job_id;
         std::string group = "Cubit-CalculiX/Results/Dat/" + std::to_string(job_id) + "/";
         cubTool.createGroup(group.c_str());
-        /*
         cubTool.write_dataset_int_rank_2("result_blocks",group.c_str(), results->dat_data[i].result_blocks);
         cubTool.write_dataset_double_rank_1("total_times",group.c_str(), results->dat_data[i].total_times);
-        cubTool.write_dataset_string_rank_2("result_block_components",group.c_str(), results->dat_data[i].result_block_components);
+        if (results->dat_data[i].result_block_components.size()>0)
+        {
+          std::string subgroup = group + "result_block_components/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->dat_data[i].result_block_components.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_string_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_components[ii]);
+          }
+        }
         cubTool.write_dataset_string_rank_1("result_block_type",group.c_str(), results->dat_data[i].result_block_type);
         cubTool.write_dataset_string_rank_1("result_block_set",group.c_str(), results->dat_data[i].result_block_set);
-        cubTool.write_dataset_double_rank_3("result_block_data",group.c_str(), results->dat_data[i].result_block_data);
-        cubTool.write_dataset_int_rank_3("result_block_c1_data",group.c_str(), results->dat_data[i].result_block_c1_data);
-        cubTool.write_dataset_double_rank_3("buckle_data",group.c_str(), results->dat_data[i].buckle_data);
-        cubTool.write_dataset_int_rank_2("sorted_c1",group.c_str(), results->dat_data[i].sorted_c1);
-        cubTool.write_dataset_int_rank_2("sorted_result_block_c1_data_id",group.c_str(), results->dat_data[i].sorted_result_block_c1_data_id);
-        cubTool.write_dataset_int_rank_2("sorted_result_block_c1_data_type",group.c_str(), results->dat_data[i].sorted_result_block_c1_data_type);
-        */
+        if (results->dat_data[i].result_block_data.size()>0)
+        {
+          std::string subgroup = group + "result_block_data/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->dat_data[i].result_block_data.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_data[ii]);
+          }
+        }
+        if (results->dat_data[i].result_block_data.size()>0)
+        {
+          std::string subgroup = group + "result_block_c1_data/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->dat_data[i].result_block_c1_data.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_int_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_c1_data[ii]);
+          }
+        }
+        if (results->dat_data[i].buckle_data.size()>0)
+        {
+          std::string subgroup = group + "buckle_data/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->dat_data[i].buckle_data.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].buckle_data[ii]);
+          }
+        }
+        if (results->dat_data[i].sorted_c1.size()>0)
+        {
+          std::string subgroup = group + "sorted_c1/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->dat_data[i].sorted_c1.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_c1[ii]);
+          }
+        }
+        if (results->dat_data[i].sorted_c1.size()>0)
+        {
+          std::string subgroup = group + "sorted_result_block_c1_data_id/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->dat_data[i].sorted_result_block_c1_data_id.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_id[ii]);
+          }
+        }
+        if (results->dat_data[i].sorted_c1.size()>0)
+        {
+          std::string subgroup = group + "sorted_result_block_c1_data_type/";
+          cubTool.createGroup(subgroup.c_str());
+          for (size_t ii = 0; ii < results->dat_data[i].sorted_result_block_c1_data_type.size(); ii++)
+          {
+            std::string dataset = std::to_string(ii);
+            cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_type[ii]);
+          }
+        }
       }
     }
     

--- a/src/Core/CalculiXCore.cpp
+++ b/src/Core/CalculiXCore.cpp
@@ -422,6 +422,14 @@ bool CalculiXCore::read_cub(std::string filename)
     PRINT_INFO("%s", log.c_str());
     return true;
   }else{
+    //General
+    std::vector<std::string> general;
+    cubTool.read_dataset_string_rank_1("general","Cubit-CalculiX", general);
+    if (general.size()>0)
+    {
+      log = "Save file was created with Cubit-CalculiX " + general[0] + "\n";
+      PRINT_INFO("%s", log.c_str());
+    }
     //Blocks
     cubTool.read_dataset_int_rank_2("blocks_data","Cubit-CalculiX/Blocks", cb->blocks_data);
     //Sections
@@ -649,88 +657,133 @@ bool CalculiXCore::read_cub(std::string filename)
         }        
       }
     }
-/*
+
     for (size_t i = 0; i < results->dat_data.size(); i++)
     {
       int job_id = results->dat_data[i].job_id;
       std::string group = "Cubit-CalculiX/Results/Dat/" + std::to_string(job_id) + "/";
-      cubTool.createGroup(group.c_str());
-      cubTool.write_dataset_int_rank_2("result_blocks",group.c_str(), results->dat_data[i].result_blocks);
-      cubTool.write_dataset_double_rank_1("total_times",group.c_str(), results->dat_data[i].total_times);
-      if (results->dat_data[i].result_block_components.size()>0)
+      std::string subgroup = group;
+      if (cubTool.nameExists(group.c_str()))
       {
-        std::string subgroup = group + "result_block_components/";
-        cubTool.createGroup(subgroup.c_str());
-        for (size_t ii = 0; ii < results->dat_data[i].result_block_components.size(); ii++)
+        cubTool.read_dataset_int_rank_2("result_blocks",group.c_str(), results->dat_data[i].result_blocks);
+        cubTool.read_dataset_double_rank_1("total_times",group.c_str(), results->dat_data[i].total_times);
+        subgroup = group + "result_block_components/";
+        if (cubTool.nameExists(subgroup.c_str()))
         {
-          std::string dataset = std::to_string(ii);
-          cubTool.write_dataset_string_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_components[ii]);
+          int ii = 0;
+          subgroup = group + "result_block_components/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "result_block_components/";
+            std::vector<std::string> tmp;
+            results->dat_data[i].result_block_components.push_back(tmp);
+            cubTool.read_dataset_string_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_components[ii]);
+            ++ii;
+            subgroup = group + "result_block_components/" + std::to_string(ii) +"/";
+          }
         }
-      }
-      cubTool.write_dataset_string_rank_1("result_block_type",group.c_str(), results->dat_data[i].result_block_type);
-      cubTool.write_dataset_string_rank_1("result_block_set",group.c_str(), results->dat_data[i].result_block_set);
-      if (results->dat_data[i].result_block_data.size()>0)
-      {
-        std::string subgroup = group + "result_block_data/";
-        cubTool.createGroup(subgroup.c_str());
-        for (size_t ii = 0; ii < results->dat_data[i].result_block_data.size(); ii++)
+        cubTool.read_dataset_string_rank_1("result_block_type",group.c_str(), results->dat_data[i].result_block_type);
+        cubTool.read_dataset_string_rank_1("result_block_set",group.c_str(), results->dat_data[i].result_block_set);
+        subgroup = group + "result_block_data/";
+        if (cubTool.nameExists(subgroup.c_str()))
         {
-          std::string dataset = std::to_string(ii);
-          cubTool.write_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_data[ii]);
+          int ii = 0;
+          subgroup = group + "result_block_data/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "result_block_data/";
+            std::vector<std::vector<double>> tmp;
+            results->dat_data[i].result_block_data.push_back(tmp);
+            cubTool.read_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_data[ii]);
+            ++ii;
+            subgroup = group + "result_block_data/" + std::to_string(ii) +"/";
+          }
         }
-      }
-      if (results->dat_data[i].result_block_data.size()>0)
-      {
-        std::string subgroup = group + "result_block_c1_data/";
-        cubTool.createGroup(subgroup.c_str());
-        for (size_t ii = 0; ii < results->dat_data[i].result_block_c1_data.size(); ii++)
+        subgroup = group + "result_block_c1_data/";
+        if (cubTool.nameExists(subgroup.c_str()))
         {
-          std::string dataset = std::to_string(ii);
-          cubTool.write_dataset_int_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_c1_data[ii]);
+          int ii = 0;
+          subgroup = group + "result_block_c1_data/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "result_block_c1_data/";
+            std::vector<std::vector<int>> tmp;
+            results->dat_data[i].result_block_c1_data.push_back(tmp);
+            cubTool.read_dataset_int_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_c1_data[ii]);
+            ++ii;
+            subgroup = group + "result_block_c1_data/" + std::to_string(ii) +"/";
+          }
         }
-      }
-      if (results->dat_data[i].buckle_data.size()>0)
-      {
-        std::string subgroup = group + "buckle_data/";
-        cubTool.createGroup(subgroup.c_str());
-        for (size_t ii = 0; ii < results->dat_data[i].buckle_data.size(); ii++)
+        subgroup = group + "buckle_data/";
+        if (cubTool.nameExists(subgroup.c_str()))
         {
-          std::string dataset = std::to_string(ii);
-          cubTool.write_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].buckle_data[ii]);
+          int ii = 0;
+          subgroup = group + "buckle_data/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "buckle_data/";
+            std::vector<std::vector<double>> tmp;
+            results->dat_data[i].buckle_data.push_back(tmp);
+            cubTool.read_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].buckle_data[ii]);
+            ++ii;
+            subgroup = group + "buckle_data/" + std::to_string(ii) +"/";
+          }
         }
-      }
-      if (results->dat_data[i].sorted_c1.size()>0)
-      {
-        std::string subgroup = group + "sorted_c1/";
-        cubTool.createGroup(subgroup.c_str());
-        for (size_t ii = 0; ii < results->dat_data[i].sorted_c1.size(); ii++)
+        subgroup = group + "sorted_c1/";
+        if (cubTool.nameExists(subgroup.c_str()))
         {
-          std::string dataset = std::to_string(ii);
-          cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_c1[ii]);
+          int ii = 0;
+          subgroup = group + "sorted_c1/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "sorted_c1/";
+            std::vector<int> tmp;
+            results->dat_data[i].sorted_c1.push_back(tmp);
+            cubTool.read_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_c1[ii]);
+            ++ii;
+            subgroup = group + "sorted_c1/" + std::to_string(ii) +"/";
+          }
         }
-      }
-      if (results->dat_data[i].sorted_c1.size()>0)
-      {
-        std::string subgroup = group + "sorted_result_block_c1_data_id/";
-        cubTool.createGroup(subgroup.c_str());
-        for (size_t ii = 0; ii < results->dat_data[i].sorted_result_block_c1_data_id.size(); ii++)
+        subgroup = group + "sorted_result_block_c1_data_id/";
+        if (cubTool.nameExists(subgroup.c_str()))
         {
-          std::string dataset = std::to_string(ii);
-          cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_id[ii]);
+          int ii = 0;
+          subgroup = group + "sorted_result_block_c1_data_id/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "sorted_result_block_c1_data_id/";
+            std::vector<int> tmp;
+            results->dat_data[i].sorted_result_block_c1_data_id.push_back(tmp);
+            cubTool.read_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_id[ii]);
+            ++ii;
+            subgroup = group + "sorted_result_block_c1_data_id/" + std::to_string(ii) +"/";
+          }
         }
-      }
-      if (results->dat_data[i].sorted_c1.size()>0)
-      {
-        std::string subgroup = group + "sorted_result_block_c1_data_type/";
-        cubTool.createGroup(subgroup.c_str());
-        for (size_t ii = 0; ii < results->dat_data[i].sorted_result_block_c1_data_type.size(); ii++)
+        subgroup = group + "sorted_result_block_c1_data_type/";
+        if (cubTool.nameExists(subgroup.c_str()))
         {
-          std::string dataset = std::to_string(ii);
-          cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_type[ii]);
+          int ii = 0;
+          subgroup = group + "sorted_result_block_c1_data_type/" + std::to_string(ii) +"/";
+          while (cubTool.nameExists(subgroup.c_str()))
+          {
+            std::string dataset = std::to_string(ii);
+            subgroup = group + "sorted_result_block_c1_data_type/";
+            std::vector<int> tmp;
+            results->dat_data[i].sorted_result_block_c1_data_type.push_back(tmp);
+            cubTool.read_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_type[ii]);
+            ++ii;
+            subgroup = group + "sorted_result_block_c1_data_type/" + std::to_string(ii) +"/";
+          }
         }
       }
     }
-*/
+
 
     //CustomLines
     cubTool.read_dataset_string_rank_2("customlines_data","Cubit-CalculiX/CustomLines", customlines->customlines_data);
@@ -771,6 +824,9 @@ bool CalculiXCore::save_cub(std::string filename)
   {
     //General
     cubTool.createGroup("Cubit-CalculiX");
+    std::vector<std::string> general;
+    general.push_back(this->version); //version info
+    cubTool.write_dataset_string_rank_1("general","Cubit-CalculiX", general);
     //Core
     cubTool.createGroup("Cubit-CalculiX/Core");
     //Blocks
@@ -962,7 +1018,7 @@ bool CalculiXCore::save_cub(std::string filename)
             cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->frd_data[i].sorted_result_node_ids[ii]);
           }
         }
-        if (results->frd_data[i].sorted_result_node_ids.size()>0)
+        if (results->frd_data[i].sorted_result_node_data_ids.size()>0)
         {
           std::string subgroup = group + "sorted_result_node_data_ids/";
           cubTool.createGroup(subgroup.c_str());
@@ -1002,7 +1058,7 @@ bool CalculiXCore::save_cub(std::string filename)
             cubTool.write_dataset_double_rank_2(dataset.c_str(),subgroup.c_str(), results->dat_data[i].result_block_data[ii]);
           }
         }
-        if (results->dat_data[i].result_block_data.size()>0)
+        if (results->dat_data[i].result_block_c1_data.size()>0)
         {
           std::string subgroup = group + "result_block_c1_data/";
           cubTool.createGroup(subgroup.c_str());
@@ -1032,7 +1088,7 @@ bool CalculiXCore::save_cub(std::string filename)
             cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_c1[ii]);
           }
         }
-        if (results->dat_data[i].sorted_c1.size()>0)
+        if (results->dat_data[i].sorted_result_block_c1_data_id.size()>0)
         {
           std::string subgroup = group + "sorted_result_block_c1_data_id/";
           cubTool.createGroup(subgroup.c_str());
@@ -1042,7 +1098,7 @@ bool CalculiXCore::save_cub(std::string filename)
             cubTool.write_dataset_int_rank_1(dataset.c_str(),subgroup.c_str(), results->dat_data[i].sorted_result_block_c1_data_id[ii]);
           }
         }
-        if (results->dat_data[i].sorted_c1.size()>0)
+        if (results->dat_data[i].sorted_result_block_c1_data_type.size()>0)
         {
           std::string subgroup = group + "sorted_result_block_c1_data_type/";
           cubTool.createGroup(subgroup.c_str());

--- a/src/Core/CalculiXCore.cpp
+++ b/src/Core/CalculiXCore.cpp
@@ -719,7 +719,51 @@ bool CalculiXCore::save_cub(std::string filename)
     cubTool.write_dataset_int_rank_2("results_data","Cubit-CalculiX/Results", results->results_data);
     cubTool.createGroup("Cubit-CalculiX/Results/Frd");
     cubTool.createGroup("Cubit-CalculiX/Results/Dat");
-
+    if (ccx_uo.mSaveLoadedResults)
+    {
+      for (size_t i = 0; i < results->frd_data.size(); i++)
+      {
+        int job_id = results->frd_data[i].job_id;
+        std::string group = "Cubit-CalculiX/Results/Frd/" + std::to_string(job_id) + "/";
+        cubTool.createGroup(group.c_str());
+        cubTool.write_dataset_string_rank_2("header",group.c_str(), results->frd_data[i].header);
+        cubTool.write_dataset_string_rank_2("materials",group.c_str(), results->frd_data[i].materials);
+        cubTool.write_dataset_int_rank_2("nodes",group.c_str(), results->frd_data[i].nodes);
+        cubTool.write_dataset_double_rank_2("nodes_coords",group.c_str(), results->frd_data[i].nodes_coords);
+        cubTool.write_dataset_int_rank_2("elements",group.c_str(), results->frd_data[i].elements);
+        cubTool.write_dataset_int_rank_2("elements_connectivity",group.c_str(), results->frd_data[i].elements_connectivity);
+        cubTool.write_dataset_int_rank_2("result_blocks",group.c_str(), results->frd_data[i].result_blocks);
+        cubTool.write_dataset_double_rank_1("total_times",group.c_str(), results->frd_data[i].total_times);
+        cubTool.write_dataset_string_rank_2("result_block_components",group.c_str(), results->frd_data[i].result_block_components);
+        cubTool.write_dataset_string_rank_1("result_block_type",group.c_str(), results->frd_data[i].result_block_type);
+        cubTool.write_dataset_double_rank_3("result_block_data",group.c_str(), results->frd_data[i].result_block_data);
+        cubTool.write_dataset_int_rank_3("result_block_node_data",group.c_str(), results->frd_data[i].result_block_node_data);
+        cubTool.write_dataset_int_rank_1("sorted_node_ids",group.c_str(), results->frd_data[i].sorted_node_ids);
+        cubTool.write_dataset_int_rank_1("sorted_node_data_ids",group.c_str(), results->frd_data[i].sorted_node_data_ids);
+        cubTool.write_dataset_int_rank_2("sorted_result_node_ids",group.c_str(), results->frd_data[i].sorted_result_node_ids);
+        cubTool.write_dataset_int_rank_2("sorted_result_node_data_ids",group.c_str(), results->frd_data[i].sorted_result_node_data_ids);
+      }
+      for (size_t i = 0; i < results->dat_data.size(); i++)
+      {
+        int job_id = results->dat_data[i].job_id;
+        std::string group = "Cubit-CalculiX/Results/Dat/" + std::to_string(job_id) + "/";
+        cubTool.createGroup(group.c_str());
+        /*
+        cubTool.write_dataset_int_rank_2("result_blocks",group.c_str(), results->dat_data[i].result_blocks);
+        cubTool.write_dataset_double_rank_1("total_times",group.c_str(), results->dat_data[i].total_times);
+        cubTool.write_dataset_string_rank_2("result_block_components",group.c_str(), results->dat_data[i].result_block_components);
+        cubTool.write_dataset_string_rank_1("result_block_type",group.c_str(), results->dat_data[i].result_block_type);
+        cubTool.write_dataset_string_rank_1("result_block_set",group.c_str(), results->dat_data[i].result_block_set);
+        cubTool.write_dataset_double_rank_3("result_block_data",group.c_str(), results->dat_data[i].result_block_data);
+        cubTool.write_dataset_int_rank_3("result_block_c1_data",group.c_str(), results->dat_data[i].result_block_c1_data);
+        cubTool.write_dataset_double_rank_3("buckle_data",group.c_str(), results->dat_data[i].buckle_data);
+        cubTool.write_dataset_int_rank_2("sorted_c1",group.c_str(), results->dat_data[i].sorted_c1);
+        cubTool.write_dataset_int_rank_2("sorted_result_block_c1_data_id",group.c_str(), results->dat_data[i].sorted_result_block_c1_data_id);
+        cubTool.write_dataset_int_rank_2("sorted_result_block_c1_data_type",group.c_str(), results->dat_data[i].sorted_result_block_c1_data_type);
+        */
+      }
+    }
+    
     //CustomLines
     cubTool.createGroup("Cubit-CalculiX/CustomLines");
     cubTool.write_dataset_string_rank_2("customlines_data","Cubit-CalculiX/CustomLines", customlines->customlines_data);

--- a/src/Core/CalculiXCore.cpp
+++ b/src/Core/CalculiXCore.cpp
@@ -529,23 +529,18 @@ bool CalculiXCore::read_cub(std::string filename)
     //Jobs
     if (cubTool.read_dataset_string_rank_2("jobs_data","Cubit-CalculiX/Jobs", jobs->jobs_data))
     {
-      if (!cubTool.read_dataset_string_rank_2("output_console","Cubit-CalculiX/Jobs", jobs->output_console))
+      for (size_t i = 0; i < jobs->jobs_data.size(); i++)
       {
         std::vector<std::string> tmp_output_console;
         jobs->output_console.push_back(tmp_output_console);
-        jobs->jobs_data[jobs->jobs_data.size()-1][5] = std::to_string(jobs->output_console.size()-1);
-      }
-      if (!cubTool.read_dataset_string_rank_2("cvg","Cubit-CalculiX/Jobs", jobs->cvg))
-      {
         std::vector<std::string> tmp_cvg;
         jobs->cvg.push_back(tmp_cvg);
-        jobs->jobs_data[jobs->jobs_data.size()-1][7] = std::to_string(jobs->cvg.size()-1);
-      }
-      if (!cubTool.read_dataset_string_rank_2("sta","Cubit-CalculiX/Jobs", jobs->sta))
-      {
         std::vector<std::string> tmp_sta;
         jobs->sta.push_back(tmp_sta);
-        jobs->jobs_data[jobs->jobs_data.size()-1][8] = std::to_string(jobs->sta.size()-1);
+        std::string dataset = std::to_string(i);
+        cubTool.read_dataset_string_rank_1(dataset,"Cubit-CalculiX/Jobs/output_console", jobs->output_console[i]);
+        cubTool.read_dataset_string_rank_1(dataset,"Cubit-CalculiX/Jobs/cvg", jobs->cvg[i]);
+        cubTool.read_dataset_string_rank_1(dataset,"Cubit-CalculiX/Jobs/sta", jobs->sta[i]);
       }
     }
     //Results
@@ -951,10 +946,17 @@ bool CalculiXCore::save_cub(std::string filename)
     cubTool.write_dataset_int_rank_2("fieldoutputs_data","Cubit-CalculiX/Steps", steps->fieldoutputs_data);
     //Jobs
     cubTool.createGroup("Cubit-CalculiX/Jobs");
+    cubTool.createGroup("Cubit-CalculiX/Jobs/output_console");
+    cubTool.createGroup("Cubit-CalculiX/Jobs/cvg");
+    cubTool.createGroup("Cubit-CalculiX/Jobs/sta");
     cubTool.write_dataset_string_rank_2("jobs_data","Cubit-CalculiX/Jobs", jobs->jobs_data);
-    cubTool.write_dataset_string_rank_2("output_console","Cubit-CalculiX/Jobs", jobs->output_console);
-    cubTool.write_dataset_string_rank_2("cvg","Cubit-CalculiX/Jobs", jobs->cvg);
-    cubTool.write_dataset_string_rank_2("sta","Cubit-CalculiX/Jobs", jobs->sta);
+    for (size_t i = 0; i < jobs->jobs_data.size(); i++)
+    {
+      std::string dataset = std::to_string(i);
+      cubTool.write_dataset_string_rank_1(dataset.c_str(),"Cubit-CalculiX/Jobs/output_console", jobs->output_console[i]);
+      cubTool.write_dataset_string_rank_1(dataset.c_str(),"Cubit-CalculiX/Jobs/cvg", jobs->cvg[i]);
+      cubTool.write_dataset_string_rank_1(dataset.c_str(),"Cubit-CalculiX/Jobs/sta", jobs->sta[i]);
+    }
     //Results
     cubTool.createGroup("Cubit-CalculiX/Results");
     cubTool.write_dataset_int_rank_2("results_data","Cubit-CalculiX/Results", results->results_data);

--- a/src/Core/CoreResultsVtkWriter.cpp
+++ b/src/Core/CoreResultsVtkWriter.cpp
@@ -435,10 +435,6 @@ bool CoreResultsVtkWriter::write_linked_parallel()
     this->link_dat_parallel();
   }
 
-  std::string log = "geht main loop\n";
-  PRINT_INFO("%s", log.c_str());
-  return false;
-
   progressbar->start(0,100,"Writing Results to ParaView Format - Linked Mode");
   this->t_start = std::chrono::high_resolution_clock::now();
 
@@ -4500,6 +4496,22 @@ bool CoreResultsVtkWriter::link_dat_parallel()
   int number_of_parts = nparts_dat;
   int loop_c = 0;
   int it=0;
+
+  //create space for every part
+  for (size_t i = 0; i < number_of_parts; i++)
+  {
+    std::vector<std::vector<int>> tmp_1;
+    std::vector<std::vector<double>> tmp_2;
+    std::vector<std::vector<std::vector<double>>> tmp_3;
+    std::vector<std::vector<int>> tmp_4;
+    std::vector<int> tmp_5;
+    set_ip_nodes.push_back(tmp_1);
+    set_ip_nodes_coords.push_back(tmp_2);
+    set_nodes_coords.push_back(tmp_3);
+    set_element_type_connectivity.push_back(tmp_4);
+    set_ipmax.push_back(tmp_5);
+  }
+  
   while (number_of_parts > 0)
   {
     if (number_of_parts > max_threads)
@@ -4535,10 +4547,6 @@ bool CoreResultsVtkWriter::link_dat_parallel()
     }
     ++loop_c;
   }
-
-  std::string log = "sub loop\n";
-  PRINT_INFO("%s", log.c_str());
-  return false;
 
   // link result blocks
   progressbar->start(0,100,"Linking DAT: Result Blocks");
@@ -4864,18 +4872,11 @@ bool CoreResultsVtkWriter::link_dat_nodes_elements_thread(int thread_part,std::v
       }
 
       // to skip rest and go for the next set
-      set_ip_nodes.push_back(ip_nodes);
-      set_ip_nodes_coords.push_back(ip_nodes_coords);
-      
-      std::string log = "thread\n";
-      log.append(std::to_string(ii)+ " \n");
-      PRINT_INFO("%s", log.c_str());
-      return false;
-
-      set_nodes_coords.push_back(tmp_set_nodes_coords);
-      
-      set_element_type_connectivity.push_back(tmp_set_element_type_connectivity);
-      set_ipmax.push_back(tmp_set_ipmax);
+      set_ip_nodes[thread_part-(nparts-nparts_dat)] = ip_nodes;
+      set_ip_nodes_coords[thread_part-(nparts-nparts_dat)] = ip_nodes_coords;
+      set_nodes_coords[thread_part-(nparts-nparts_dat)] = tmp_set_nodes_coords;
+      set_element_type_connectivity[thread_part-(nparts-nparts_dat)] = tmp_set_element_type_connectivity;
+      set_ipmax[thread_part-(nparts-nparts_dat)] = tmp_set_ipmax;
 
       ii = dat_all->result_blocks.size();
     }

--- a/src/Core/CoreResultsVtkWriter.cpp
+++ b/src/Core/CoreResultsVtkWriter.cpp
@@ -434,95 +434,13 @@ bool CoreResultsVtkWriter::write_linked_parallel()
     //link dat
     this->link_dat_parallel();
   }
+
+  std::string log = "geht main loop\n";
+  PRINT_INFO("%s", log.c_str());
+  return false;
+
   progressbar->start(0,100,"Writing Results to ParaView Format - Linked Mode");
   this->t_start = std::chrono::high_resolution_clock::now();
-
-  /*
-
-  this->progress = std::vector<int>(max_threads + 1, 0);
-  progress[max_threads] = max_increments*nparts;
-
-  current_increment = 0;
-  //StopWatch StopWatch;
-
-  for (size_t i = 0; i < max_increments; i++)
-  {
-    //StopWatch.tick("Increment " + std::to_string(i) + " start");
-    filepath_vtu.clear();
-    part_ids.clear();
-
-    ++current_increment;
-    current_part = -1;
-    int loop_c = 0;
-    int number_of_frd = vec_frd.size();
-    int it=0;
-
-    current_offset_thread.clear();
-    linked_nodes_thread.clear();
-    linked_nodes_data_id_thread.clear();
-    rangeMin_thread.clear();
-    rangeMax_thread.clear();
-    
-    for (size_t ii = 0; ii < number_of_frd; ii++)
-    {
-      current_offset_thread.push_back({});
-      linked_nodes_thread.push_back({});
-      linked_nodes_data_id_thread.push_back({});
-      rangeMin_thread.push_back({});
-      rangeMax_thread.push_back({});
-    }
-    
-    while (number_of_frd > 0)
-    {
-      //StopWatch.tick("thread loop " + std::to_string(loop_c) + " start" );
-      if (number_of_frd > max_threads)
-      {
-        for (size_t ii = 0; ii < max_threads; ii++)
-        { 
-          std::string thread_filepath_vtu;
-          thread_filepath_vtu = filepath + "/" + filepath + "." + std::to_string(loop_c*max_threads+ii) + "." + this->get_increment() + ".vtu";
-          filepath_vtu.push_back(filepath + "." + std::to_string(loop_c*max_threads+ii) + "." + this->get_increment() + ".vtu");
-          part_ids.push_back(loop_c*max_threads+ii);
-          
-          WriteThreads.push_back(std::thread(&CoreResultsVtkWriter::write_vtu_linked_thread, this,loop_c*max_threads+ii,thread_filepath_vtu));
-        }
-      }else{
-        for (size_t ii = 0; ii < number_of_frd; ii++)
-        { 
-          std::string thread_filepath_vtu;
-          thread_filepath_vtu = filepath + "/" + filepath + "." + std::to_string(loop_c*max_threads+ii) + "." + this->get_increment() + ".vtu";
-          filepath_vtu.push_back(filepath + "." + std::to_string(loop_c*max_threads+ii) + "." + this->get_increment() + ".vtu");
-          part_ids.push_back(loop_c*max_threads+ii);
-
-          WriteThreads.push_back(std::thread(&CoreResultsVtkWriter::write_vtu_linked_thread, this,loop_c*max_threads+ii,thread_filepath_vtu));
-        }
-      }
-      //StopWatch.tick("thread loop end");
-      it=0;
-      while (WriteThreads.size()>0)
-      {
-        if (WriteThreads[it].joinable())
-        {
-          WriteThreads[it].join();
-          WriteThreads.erase(WriteThreads.begin() + it);
-          ++progress[it];
-          number_of_frd = number_of_frd - 1;
-          it=-1;
-        }
-        if (it==WriteThreads.size())
-        {
-          it=-1;
-        }
-        update_progressbar();
-        ++it;
-      }
-      ++loop_c; 
-    }
-    current_filepath_vtpc = filepath + "/" + filepath + "." + this->get_increment() + ".vtpc";
-    this->write_vtpc();
-    //StopWatch.tick("Increment end " + std::to_string(i));
-  }
-  */
 
   this->progress = std::vector<int>(max_threads + 1, 0);
   progress[max_threads] = max_increments*nparts;
@@ -3366,7 +3284,7 @@ bool CoreResultsVtkWriter::link_nodes_parallel()
   for (size_t i = 0; i < sideset_ids.size(); i++)
   { 
     tmp_part_node_ids.push_back(sideset_node_ids[i]);
-    std::sort(tmp_part_node_ids[block_ids.size()+sideset_ids.size()+i].begin(), tmp_part_node_ids[block_ids.size()+sideset_ids.size()+i].end());
+    std::sort(tmp_part_node_ids[block_ids.size()+nodeset_ids.size()+i].begin(), tmp_part_node_ids[block_ids.size()+nodeset_ids.size()+i].end());
   }
 
   progressbar->start(0,100,"Linking Nodes");
@@ -3440,56 +3358,6 @@ bool CoreResultsVtkWriter::link_nodes_parallel()
       progress[max_threads] = progress[max_threads] + int(tmp_part_node_ids[ii].size()) * int(data_ids.size());
     }
   }
-
-/*
-  current_increment = 0;
-  for (size_t i = 0; i < max_increments; i++)
-  {
-    ++current_increment;
-    std::vector<int> data_ids = this->get_result_blocks_data_ids_linked(); // get data ids for result blocks
-    for (size_t ii = 0; ii < data_ids.size(); ii++)
-    {
-      int number_of_parts = nparts - nparts_dat;
-      int loop_c = 0;
-      
-      while (number_of_parts > 0)
-      {
-        if (number_of_parts > max_threads)
-        {
-          for (size_t iii = 0; iii < max_threads; iii++)
-          {      
-            LinkThreads.push_back(std::thread(&CoreResultsVtkWriter::link_nodes_result_blocks_thread, this,loop_c*max_threads+iii,tmp_part_node_ids[loop_c*max_threads+iii],data_ids[ii],iii));
-          }
-        }else{
-          for (size_t iii = 0; iii < number_of_parts; iii++)
-          { 
-            LinkThreads.push_back(std::thread(&CoreResultsVtkWriter::link_nodes_result_blocks_thread, this,loop_c*max_threads+iii,tmp_part_node_ids[loop_c*max_threads+iii],data_ids[ii],iii));
-          }
-        }
-        // wait till all threads are finished
-        it=0;
-        while (LinkThreads.size()>0)
-        {
-          if (LinkThreads[it].joinable())
-          {
-            LinkThreads[it].join();
-            LinkThreads.erase(LinkThreads.begin() + it);
-            number_of_parts = number_of_parts - 1;
-            it=-1;
-          }
-          if (it==LinkThreads.size())
-          {
-            it=-1;
-          }
-          update_progressbar();
-          ++it;
-        }
-        ++loop_c; 
-      }
-    }
-  }
-  current_increment = 0;
-*/
 
   // create data structure before using threadpool
   current_increment = 0;
@@ -4668,6 +4536,10 @@ bool CoreResultsVtkWriter::link_dat_parallel()
     ++loop_c;
   }
 
+  std::string log = "sub loop\n";
+  PRINT_INFO("%s", log.c_str());
+  return false;
+
   // link result blocks
   progressbar->start(0,100,"Linking DAT: Result Blocks");
   this->t_start = std::chrono::high_resolution_clock::now();
@@ -4818,7 +4690,7 @@ bool CoreResultsVtkWriter::link_dat_nodes_elements_thread(int thread_part,std::v
             only_one_ip = false;
           }
         }
-        
+      
         for (size_t iii = 0; iii < dat_all->result_block_c1_data[dat_all->result_blocks[ii][4]].size(); iii++)
         {
           ip = int(dat_all->result_block_data[dat_all->result_blocks[ii][4]][dat_all->result_block_c1_data[dat_all->result_blocks[ii][4]][iii][1]][1]);
@@ -4970,7 +4842,6 @@ bool CoreResultsVtkWriter::link_dat_nodes_elements_thread(int thread_part,std::v
           vec_frd[thread_part]->elements[vec_frd[thread_part]->elements.size()-1][2] = int(vec_frd[thread_part]->elements_connectivity.size())-1;
         }
       }
-
       // elements
       if (dat_all->result_block_c1_data[dat_all->result_blocks[ii][4]][0][2] == 1) // nodeset
       {
@@ -4991,10 +4862,18 @@ bool CoreResultsVtkWriter::link_dat_nodes_elements_thread(int thread_part,std::v
         }
         //this->stopwatch("elements elset ip");
       }
+
       // to skip rest and go for the next set
       set_ip_nodes.push_back(ip_nodes);
       set_ip_nodes_coords.push_back(ip_nodes_coords);
+      
+      std::string log = "thread\n";
+      log.append(std::to_string(ii)+ " \n");
+      PRINT_INFO("%s", log.c_str());
+      return false;
+
       set_nodes_coords.push_back(tmp_set_nodes_coords);
+      
       set_element_type_connectivity.push_back(tmp_set_element_type_connectivity);
       set_ipmax.push_back(tmp_set_ipmax);
 

--- a/src/UserOptions/ConfigFile.cpp
+++ b/src/UserOptions/ConfigFile.cpp
@@ -144,6 +144,42 @@ void ConfigFile::read_num_entry(std::string option, int &value)
     }
 }
 
+void ConfigFile::read_bool_entry(std::string option, bool &value)
+{
+    std::ifstream input_file;
+    QString cfgvalue;
+    input_file.open(filepath.c_str());
+    if (input_file)
+    {
+        for( std::string line; std::getline( input_file, line ); )
+        {
+            if (line.find(option) != std::string::npos)
+            {
+                //std::cout << line.substr(option.length()+1) << "\n";
+                if (line.substr(option.length(),1)=="=")
+                {
+                    cfgvalue = QString::fromStdString(line.substr(option.length()+1));
+                    if (cfgvalue=="")
+                    {
+                        value = standard_bool_entry(option);
+                    }
+                    if (cfgvalue=="true")
+                    {
+                        value = true;
+                    }
+                    if (cfgvalue=="false")
+                    {
+                        value = false;
+                    }
+                }
+            }
+        }
+        input_file.close();
+    }else{
+        value = standard_bool_entry(option);
+    }
+}
+
 void ConfigFile::write_entry(std::string option, QString value)
 {
     std::ofstream output_file;
@@ -160,6 +196,18 @@ void ConfigFile::write_num_entry(std::string option, int value)
     output_file.close();
 }
 
+void ConfigFile::write_bool_entry(std::string option, bool value)
+{
+    std::ofstream output_file;
+    output_file.open(filepath.c_str(), std::ios_base::app);
+    if (value)
+    {
+        output_file << option << "=true\n";
+    }else{
+        output_file << option << "=false\n";
+    }
+    output_file.close();
+}
 
 QString ConfigFile::standard_entry(std::string option)
 {
@@ -220,6 +268,18 @@ int ConfigFile::standard_num_entry(std::string option)
         #else
             standard_value = 8;
         #endif
+    }
+    
+    return standard_value;
+}
+
+bool ConfigFile::standard_bool_entry(std::string option)
+{
+    bool standard_value = true;
+
+    if (option == "mSaveLoadedResults")
+    {
+        standard_value = true;
     }
     
     return standard_value;

--- a/src/UserOptions/ConfigFile.hpp
+++ b/src/UserOptions/ConfigFile.hpp
@@ -18,10 +18,13 @@ class ConfigFile
   void clear();
   void read_entry(std::string option, QString &value);
   void read_num_entry(std::string option, int &value);
+  void read_bool_entry(std::string option, bool &value);
   void write_entry(std::string option, QString value);
   void write_num_entry(std::string option, int value);
+  void write_bool_entry(std::string option, bool value);
   QString standard_entry(std::string option);
   int standard_num_entry(std::string option);
+  bool standard_bool_entry(std::string option);
 };
 
 #endif // CONFIGFILE_HPP

--- a/src/UserOptions/UserOptions.hpp
+++ b/src/UserOptions/UserOptions.hpp
@@ -23,6 +23,8 @@ class UserOptions
     QString mPathIconsName;
     QString mPathPythonInterface;
     QString mPathPythonInterfaceName;
+    bool mSaveLoadedResults;
+    QString mSaveLoadedResultsName;
 };
 
 #endif // USEROPTIONS_HPP

--- a/src/UserOptions/UserOptionsPanel.cpp
+++ b/src/UserOptions/UserOptionsPanel.cpp
@@ -21,6 +21,7 @@ UserOptionsPanel::UserOptionsPanel(QWidget *parent) :
   HBoxLayout_5 = new QHBoxLayout();
   HBoxLayout_6 = new QHBoxLayout();
   HBoxLayout_7 = new QHBoxLayout();
+  HBoxLayout_8 = new QHBoxLayout();
   label_1 = new QLabel();
   label_2 = new QLabel();
   label_3 = new QLabel();
@@ -28,6 +29,7 @@ UserOptionsPanel::UserOptionsPanel(QWidget *parent) :
   label_5 = new QLabel();
   label_6 = new QLabel();
   label_7 = new QLabel();
+  label_8 = new QLabel();
   label_1->setFixedWidth(labelWidth);
   label_2->setFixedWidth(labelWidth);
   label_3->setFixedWidth(labelWidth);
@@ -35,6 +37,7 @@ UserOptionsPanel::UserOptionsPanel(QWidget *parent) :
   label_5->setFixedWidth(labelWidth);
   label_6->setFixedWidth(labelWidth);
   label_7->setFixedWidth(labelWidth);
+  label_8->setFixedWidth(labelWidth);
   lineEdit_1 = new QLineEdit();
   lineEdit_2 = new QLineEdit();
   lineEdit_3 = new QLineEdit();
@@ -42,6 +45,7 @@ UserOptionsPanel::UserOptionsPanel(QWidget *parent) :
   lineEdit_5 = new QLineEdit();
   lineEdit_6 = new QLineEdit();
   lineEdit_7 = new QLineEdit();
+  checkBox_8 = new QCheckBox();
 
   // Layout
   GridLayout->addLayout(VBoxLayout,0,0, Qt::AlignTop);
@@ -52,6 +56,7 @@ UserOptionsPanel::UserOptionsPanel(QWidget *parent) :
   VBoxLayout->addLayout(HBoxLayout_5);
   VBoxLayout->addLayout(HBoxLayout_6);
   VBoxLayout->addLayout(HBoxLayout_7);
+  VBoxLayout->addLayout(HBoxLayout_8);
   VBoxLayout->addItem(vertical_spacer);
 
   HBoxLayout_1->addWidget(label_1);
@@ -68,6 +73,8 @@ UserOptionsPanel::UserOptionsPanel(QWidget *parent) :
   HBoxLayout_6->addWidget(lineEdit_6);
   HBoxLayout_7->addWidget(label_7);
   HBoxLayout_7->addWidget(lineEdit_7);
+  HBoxLayout_8->addWidget(label_8);
+  HBoxLayout_8->addWidget(checkBox_8);
 
   isInitialized = true;
 }
@@ -84,6 +91,7 @@ void UserOptionsPanel::refresh_settings()
   label_5->setText(ccx_uo.mPathParaViewName);
   label_6->setText(ccx_uo.mPathIconsName);
   label_7->setText(ccx_uo.mPathPythonInterfaceName);
+  label_8->setText(ccx_uo.mSaveLoadedResultsName);
 
   lineEdit_1->setText(ccx_uo.mPathSolver);
   lineEdit_2->setText(QString::number(ccx_uo.mSolverThreads));
@@ -92,6 +100,8 @@ void UserOptionsPanel::refresh_settings()
   lineEdit_5->setText(ccx_uo.mPathParaView);
   lineEdit_6->setText(ccx_uo.mPathIcons);
   lineEdit_7->setText(ccx_uo.mPathPythonInterface);
+  checkBox_8->setChecked(ccx_uo.mSaveLoadedResults);
+
 }
 
 void UserOptionsPanel::save_settings()
@@ -103,4 +113,5 @@ void UserOptionsPanel::save_settings()
   ccx_uo.mPathParaView = lineEdit_5->text();
   ccx_uo.mPathIcons = lineEdit_6->text();
   ccx_uo.mPathPythonInterface = lineEdit_7->text();
+  ccx_uo.mSaveLoadedResults = checkBox_8->isChecked();
 }

--- a/src/UserOptions/UserOptionsPanel.hpp
+++ b/src/UserOptions/UserOptionsPanel.hpp
@@ -16,6 +16,7 @@
 #include <QTableWidget>
 #include <QLineEdit>
 #include <QRadioButton>
+#include <QCheckBox>
 
 class UserOptionsPanel : public QWidget
 {
@@ -43,6 +44,7 @@ private:
   QVBoxLayout* VBoxLayout_5;
   QVBoxLayout* VBoxLayout_6;
   QVBoxLayout* VBoxLayout_7;
+  QVBoxLayout* VBoxLayout_8;
   QSpacerItem* vertical_spacer;
   QHBoxLayout* HBoxLayout_1;
   QHBoxLayout* HBoxLayout_2;
@@ -51,6 +53,7 @@ private:
   QHBoxLayout* HBoxLayout_5;
   QHBoxLayout* HBoxLayout_6;
   QHBoxLayout* HBoxLayout_7;
+  QHBoxLayout* HBoxLayout_8;
   QLabel* label_1;
   QLabel* label_2;
   QLabel* label_3;
@@ -58,6 +61,7 @@ private:
   QLabel* label_5;
   QLabel* label_6;
   QLabel* label_7;
+  QLabel* label_8;
   QLineEdit* lineEdit_1;
   QLineEdit* lineEdit_2;
   QLineEdit* lineEdit_3;
@@ -65,6 +69,7 @@ private:
   QLineEdit* lineEdit_5;
   QLineEdit* lineEdit_6;
   QLineEdit* lineEdit_7;
+  QCheckBox* checkBox_8;
 };
 
 #endif // USEROPTIONSPANEL_HPP

--- a/src/Utility/HDF5Tool.cpp
+++ b/src/Utility/HDF5Tool.cpp
@@ -193,7 +193,7 @@ bool HDF5Tool::write_dataset_int_rank_2(std::string name, std::string groupname,
     dims[1]              = data[0].size();
     H5::DataSpace *dataspace = new H5::DataSpace(rank, dims);
     
-    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), H5::PredType::STD_I32BE, *dataspace));
+    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), H5::PredType::NATIVE_INT, *dataspace));
 
     // Write the data to the dataset using default memory space, file
     // space, and transfer properties.
@@ -244,6 +244,268 @@ bool HDF5Tool::write_dataset_int_rank_2(std::string name, std::string groupname,
 
   return true;
 }
+
+
+bool HDF5Tool::write_dataset_int_rank_3(std::string name, std::string groupname, std::vector<std::vector<std::vector<int>>> data)
+{
+  // Try block to detect exceptions raised by any of the calls inside it
+  try {
+    const int rank = 3;
+    if (data.size()==0)
+    {
+      return true;
+    }
+    if (data[0].size()==0)
+    {
+      return true;
+    }
+    if (data[0][0].size()==0)
+    {
+      return true;
+    }
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately
+    H5::Exception::dontPrint();
+
+    H5::Group group(this->file->openGroup(groupname.c_str()));
+    hsize_t dims[rank]; // dataset dimensions
+    dims[0]              = data.size();
+    dims[1]              = data[0].size();
+    dims[2]              = data[0][0].size();
+    H5::DataSpace *dataspace = new H5::DataSpace(rank, dims);
+    
+    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), H5::PredType::NATIVE_INT, *dataspace));
+
+    // Write the data to the dataset using default memory space, file
+    // space, and transfer properties.
+    
+    int *wdata = new int[dims[0]*dims[1]*dims[2]]; // buffer for data to write
+    
+    for (size_t i = 0; i < data.size(); i++)
+    {
+      for (size_t ii = 0; ii < data[i].size(); ii++)
+      {
+        for (size_t iii = 0; iii < data[i][ii].size(); iii++)
+        {
+          wdata[dims[1]*dims[2]*i + dims[2]*ii + iii] = data[i][ii][iii];
+        }
+      }
+    }
+    dataset->write(wdata, H5::PredType::NATIVE_INT);
+        
+    // Close all objects.
+    delete dataspace;
+    delete dataset;
+    delete wdata;
+    group.close();
+
+    return true;
+  } // end of try block
+
+  // catch failure caused by the H5File operations
+  catch (H5::FileIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  // catch failure caused by the DataSet operations
+  catch (H5::DataSetIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  return true;
+}
+
+
+bool HDF5Tool::write_dataset_double_rank_1(std::string name, std::string groupname, std::vector<double> data)
+{
+  // Try block to detect exceptions raised by any of the calls inside it
+  try {
+    //check if there is data that can be written
+    if (data.size()==0)
+    {
+      return true;
+    }
+
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately
+    H5::Exception::dontPrint();
+
+    H5::Group group(this->file->openGroup(groupname.c_str()));
+    const int rank = 1;
+    hsize_t dims[rank]; // dataset dimensions
+    dims[0]              = data.size();
+    H5::DataSpace *dataspace = new H5::DataSpace(rank, dims);
+    
+    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), H5::PredType::NATIVE_DOUBLE, *dataspace));
+
+    // Write the data to the dataset using default memory space, file
+    // space, and transfer properties.
+    double *wdata = new double [dims[0]];
+    
+    for (size_t i = 0; i < data.size(); i++)
+    {
+      wdata[i] = data[i];
+    }
+    dataset->write(wdata, H5::PredType::NATIVE_DOUBLE);
+
+    // Close all objects.
+    delete dataspace;
+    delete dataset;
+    group.close();
+    return true;
+  } // end of try block
+
+  // catch failure caused by the H5File operations
+  catch (H5::FileIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  // catch failure caused by the DataSet operations
+  catch (H5::DataSetIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  return true;
+}
+
+bool HDF5Tool::write_dataset_double_rank_2(std::string name, std::string groupname, std::vector<std::vector<double>> data)
+{
+  // Try block to detect exceptions raised by any of the calls inside it
+  try {
+    const int rank = 2;
+    if (data.size()==0)
+    {
+      return true;
+    }
+    if (data[0].size()==0)
+    {
+      return true;
+    }
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately
+    H5::Exception::dontPrint();
+
+    H5::Group group(this->file->openGroup(groupname.c_str()));
+    hsize_t dims[rank]; // dataset dimensions
+    dims[0]              = data.size();
+    dims[1]              = data[0].size();
+    H5::DataSpace *dataspace = new H5::DataSpace(rank, dims);
+    
+    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), H5::PredType::NATIVE_DOUBLE, *dataspace));
+
+    // Write the data to the dataset using default memory space, file
+    // space, and transfer properties.
+    
+    double *wdata = new double[dims[0]*dims[1]]; // buffer for data to write
+    
+    for (size_t i = 0; i < data.size(); i++)
+    {
+      for (size_t ii = 0; ii < data[i].size(); ii++)
+      {
+        wdata[dims[1]*i+ii] = data[i][ii];
+      }
+    }
+    dataset->write(wdata, H5::PredType::NATIVE_DOUBLE);
+        
+    // Close all objects.
+    delete dataspace;
+    delete dataset;
+    delete wdata;
+    group.close();
+
+    return true;
+  } // end of try block
+
+  // catch failure caused by the H5File operations
+  catch (H5::FileIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  // catch failure caused by the DataSet operations
+  catch (H5::DataSetIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  return true;
+}
+
+bool HDF5Tool::write_dataset_double_rank_3(std::string name, std::string groupname, std::vector<std::vector<std::vector<double>>> data)
+{
+  // Try block to detect exceptions raised by any of the calls inside it
+  try {
+    const int rank = 3;
+    if (data.size()==0)
+    {
+      return true;
+    }
+    if (data[0].size()==0)
+    {
+      return true;
+    }
+    if (data[0][0].size()==0)
+    {
+      return true;
+    }
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately
+    H5::Exception::dontPrint();
+
+    H5::Group group(this->file->openGroup(groupname.c_str()));
+    hsize_t dims[rank]; // dataset dimensions
+    dims[0]              = data.size();
+    dims[1]              = data[0].size();
+    dims[2]              = data[0][0].size();
+    H5::DataSpace *dataspace = new H5::DataSpace(rank, dims);
+    
+    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), H5::PredType::NATIVE_DOUBLE, *dataspace));
+
+    // Write the data to the dataset using default memory space, file
+    // space, and transfer properties.
+    
+    double *wdata = new double[dims[0]*dims[1]*dims[2]]; // buffer for data to write
+    
+    for (size_t i = 0; i < data.size(); i++)
+    {
+      for (size_t ii = 0; ii < data[i].size(); ii++)
+      {
+        for (size_t iii = 0; iii < data[i][ii].size(); iii++)
+        {
+          wdata[dims[1]*dims[2]*i + dims[2]*ii + iii] = data[i][ii][iii];
+        }
+      }
+    }
+    dataset->write(wdata, H5::PredType::NATIVE_DOUBLE);
+        
+    // Close all objects.
+    delete dataspace;
+    delete dataset;
+    delete wdata;
+    group.close();
+
+    return true;
+  } // end of try block
+
+  // catch failure caused by the H5File operations
+  catch (H5::FileIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  // catch failure caused by the DataSet operations
+  catch (H5::DataSetIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  return true;
+}
+
 
 bool HDF5Tool::read_dataset_string_rank_2(std::string name, std::string groupname, std::vector<std::vector<std::string>> &data)
 {
@@ -336,7 +598,60 @@ bool HDF5Tool::read_dataset_string_rank_2(std::string name, std::string groupnam
   return true;
 }
 
+bool HDF5Tool::write_dataset_string_rank_1(std::string name, std::string groupname, std::vector<std::string> data)
+{
+  // Try block to detect exceptions raised by any of the calls inside it
+  try {
+    const int rank = 1;
+    if (data.size()==0)
+    {
+      return true;
+    }
 
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately
+    H5::Exception::dontPrint();
+
+    H5::Group group(this->file->openGroup(groupname.c_str()));
+    hsize_t dims[rank]; // dataset dimensions
+    dims[0]              = data.size();
+    H5::DataSpace *dataspace = new H5::DataSpace(rank, dims);
+    H5::StrType datatype(H5::PredType::C_S1, H5T_VARIABLE); 
+
+    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), datatype, *dataspace));
+
+    // Write the data to the dataset using default memory space, file
+    // space, and transfer properties.
+    
+    std::vector<const char*> wdata;
+    for (size_t i = 0; i < data.size(); i++)
+    {
+      wdata.push_back(data[i].c_str());
+    }
+    dataset->write(wdata.data(), datatype);
+    
+    // Close all objects.
+    delete dataspace;
+    delete dataset;
+    group.close();
+
+    return true;
+  } // end of try block
+
+  // catch failure caused by the H5File operations
+  catch (H5::FileIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  // catch failure caused by the DataSet operations
+  catch (H5::DataSetIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  return true;
+}
 
 bool HDF5Tool::write_dataset_string_rank_2(std::string name, std::string groupname, std::vector<std::vector<std::string>> data)
 {
@@ -381,18 +696,7 @@ bool HDF5Tool::write_dataset_string_rank_2(std::string name, std::string groupna
     delete dataspace;
     delete dataset;
     group.close();
-/*
-    std::string log = "";
-    for (size_t i = 0; i < data.size(); i++)
-    {
-      for (size_t ii = 0; ii < data[i].size(); ii++)
-      {
-        log.append(data[i][ii] + " ");
-      }
-      log.append("\n");
-    }
-    PRINT_INFO("%s", log.c_str());
-*/
+
     return true;
   } // end of try block
 

--- a/src/Utility/HDF5Tool.cpp
+++ b/src/Utility/HDF5Tool.cpp
@@ -832,7 +832,7 @@ bool HDF5Tool::write_dataset_string_rank_2(std::string name, std::string groupna
       }
     }
     dataset->write(wdata.data(), datatype);
-    
+
     // Close all objects.
     delete dataspace;
     delete dataset;

--- a/src/Utility/HDF5Tool.cpp
+++ b/src/Utility/HDF5Tool.cpp
@@ -23,6 +23,78 @@ bool HDF5Tool::createGroup(std::string groupname)
   return true;
 }
 
+bool HDF5Tool::read_dataset_int_rank_1(std::string name, std::string groupname, std::vector<int> &data)
+{
+  std::string log = "";
+
+  // Try block to detect exceptions raised by any of the calls inside it
+  try {
+    const int rank = 1;
+    if (data.size()!=0)
+    {
+      log = "data not empty -> please write an issue on github\n";
+      PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately
+    H5::Exception::dontPrint();
+
+    H5::Group group(file->openGroup(groupname.c_str()));
+    if (!group.exists(name.c_str()))
+    {
+      //log = "dataset " + name + " in group " + groupname + " doesn't exist\n";
+      //PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+    
+    H5::DataSet dataset = group.openDataSet(name);
+    H5::DataSpace dataspace = dataset.getSpace();
+    const int ndims = dataspace.getSimpleExtentNdims();
+
+    if (rank!=ndims)
+    {
+      log = "ranks doesn't match in dataset " + name + " in group " + groupname + "\n";
+      PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+    
+    hsize_t dims[rank];
+    dataspace.getSimpleExtentDims(dims, NULL);
+
+    // Read the data from the dataset    
+    std::vector<int> rdata(dims[0]); // buffer for data to read
+
+    dataset.read(rdata.data(), H5::PredType::NATIVE_INT);
+
+    for (size_t i = 0; i < dims[0]; i++)
+    { 
+      data.push_back(rdata[i]);
+    }
+    
+    // Close all objects.
+    dataspace.close();
+    dataset.close();
+    group.close();
+    return true;
+  } // end of try block
+
+  // catch failure caused by the H5File operations
+  catch (H5::FileIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  // catch failure caused by the DataSet operations
+  catch (H5::DataSetIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  return true;
+}
+
 
 bool HDF5Tool::read_dataset_int_rank_2(std::string name, std::string groupname, std::vector<std::vector<int>> &data)
 {
@@ -245,79 +317,6 @@ bool HDF5Tool::write_dataset_int_rank_2(std::string name, std::string groupname,
   return true;
 }
 
-
-bool HDF5Tool::write_dataset_int_rank_3(std::string name, std::string groupname, std::vector<std::vector<std::vector<int>>> data)
-{
-  // Try block to detect exceptions raised by any of the calls inside it
-  try {
-    const int rank = 3;
-    if (data.size()==0)
-    {
-      return true;
-    }
-    if (data[0].size()==0)
-    {
-      return true;
-    }
-    if (data[0][0].size()==0)
-    {
-      return true;
-    }
-    // Turn off the auto-printing when failure occurs so that we can
-    // handle the errors appropriately
-    H5::Exception::dontPrint();
-
-    H5::Group group(this->file->openGroup(groupname.c_str()));
-    hsize_t dims[rank]; // dataset dimensions
-    dims[0]              = data.size();
-    dims[1]              = data[0].size();
-    dims[2]              = data[0][0].size();
-    H5::DataSpace *dataspace = new H5::DataSpace(rank, dims);
-    
-    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), H5::PredType::NATIVE_INT, *dataspace));
-
-    // Write the data to the dataset using default memory space, file
-    // space, and transfer properties.
-    
-    int *wdata = new int[dims[0]*dims[1]*dims[2]]; // buffer for data to write
-    
-    for (size_t i = 0; i < data.size(); i++)
-    {
-      for (size_t ii = 0; ii < data[i].size(); ii++)
-      {
-        for (size_t iii = 0; iii < data[i][ii].size(); iii++)
-        {
-          wdata[dims[1]*dims[2]*i + dims[2]*ii + iii] = data[i][ii][iii];
-        }
-      }
-    }
-    dataset->write(wdata, H5::PredType::NATIVE_INT);
-        
-    // Close all objects.
-    delete dataspace;
-    delete dataset;
-    delete wdata;
-    group.close();
-
-    return true;
-  } // end of try block
-
-  // catch failure caused by the H5File operations
-  catch (H5::FileIException error) {
-      error.printErrorStack();
-      return false;
-  }
-
-  // catch failure caused by the DataSet operations
-  catch (H5::DataSetIException error) {
-      error.printErrorStack();
-      return false;
-  }
-
-  return true;
-}
-
-
 bool HDF5Tool::write_dataset_double_rank_1(std::string name, std::string groupname, std::vector<double> data)
 {
   // Try block to detect exceptions raised by any of the calls inside it
@@ -371,6 +370,160 @@ bool HDF5Tool::write_dataset_double_rank_1(std::string name, std::string groupna
 
   return true;
 }
+
+
+bool HDF5Tool::read_dataset_double_rank_1(std::string name, std::string groupname, std::vector<double> &data)
+{
+  std::string log = "";
+
+  // Try block to detect exceptions raised by any of the calls inside it
+  try {
+    const int rank = 1;
+    if (data.size()!=0)
+    {
+      log = "data not empty -> please write an issue on github\n";
+      PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately
+    H5::Exception::dontPrint();
+
+    H5::Group group(file->openGroup(groupname.c_str()));
+    if (!group.exists(name.c_str()))
+    {
+      //log = "dataset " + name + " in group " + groupname + " doesn't exist\n";
+      //PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+    
+    H5::DataSet dataset = group.openDataSet(name);
+    H5::DataSpace dataspace = dataset.getSpace();
+    const int ndims = dataspace.getSimpleExtentNdims();
+
+    if (rank!=ndims)
+    {
+      log = "ranks doesn't match in dataset " + name + " in group " + groupname + "\n";
+      PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+    
+    hsize_t dims[rank];
+    dataspace.getSimpleExtentDims(dims, NULL);
+
+    // Read the data from the dataset    
+    std::vector<double> rdata(dims[0]); // buffer for data to read
+
+    dataset.read(rdata.data(), H5::PredType::NATIVE_DOUBLE);
+
+    for (size_t i = 0; i < dims[0]; i++)
+    { 
+      data.push_back(rdata[i]);
+    }
+    
+    // Close all objects.
+    dataspace.close();
+    dataset.close();
+    group.close();
+    return true;
+  } // end of try block
+
+  // catch failure caused by the H5File operations
+  catch (H5::FileIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  // catch failure caused by the DataSet operations
+  catch (H5::DataSetIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  return true;
+}
+
+
+bool HDF5Tool::read_dataset_double_rank_2(std::string name, std::string groupname, std::vector<std::vector<double>> &data)
+{
+  std::string log = "";
+
+  // Try block to detect exceptions raised by any of the calls inside it
+  try {
+    const int rank = 2;
+    if (data.size()!=0)
+    {
+      log = "data not empty -> please write an issue on github\n";
+      PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+
+    // Turn off the auto-printing when failure occurs so that we can
+    // handle the errors appropriately
+    H5::Exception::dontPrint();
+
+    H5::Group group(file->openGroup(groupname.c_str()));
+    if (!group.exists(name.c_str()))
+    {
+      //log = "dataset " + name + " in group " + groupname + " doesn't exist\n";
+      //PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+    
+    H5::DataSet dataset = group.openDataSet(name);
+    H5::DataSpace dataspace = dataset.getSpace();
+    const int ndims = dataspace.getSimpleExtentNdims();
+
+    if (rank!=ndims)
+    {
+      log = "ranks doesn't match in dataset " + name + " in group " + groupname + "\n";
+      PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+    
+    hsize_t dims[rank];
+    dataspace.getSimpleExtentDims(dims, NULL);
+
+    // Read the data from the dataset    
+    std::vector<double> rdata(dims[0]*dims[1]); // buffer for data to read
+
+    dataset.read(rdata.data(), H5::PredType::NATIVE_DOUBLE);
+    
+    for (size_t i = 0; i < dims[0]; i++)
+    { 
+      std::vector<double> tmp;
+      for (size_t ii = 0; ii < dims[1]; ii++)
+      { 
+        tmp.push_back(rdata[dims[1]*i+ii]);
+        //log = "data.size() " + std::to_string(data.size()) + " i " + std::to_string(i) + " rdata[dims[1]*i+ii] " + std::to_string(rdata[dims[1]*i+ii]) + "\n";
+        //PRINT_INFO("%s", log.c_str());
+      }
+      data.push_back(tmp);
+    }
+    
+    // Close all objects.
+    dataspace.close();
+    dataset.close();
+    group.close();
+    return true;
+  } // end of try block
+
+  // catch failure caused by the H5File operations
+  catch (H5::FileIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  // catch failure caused by the DataSet operations
+  catch (H5::DataSetIException error) {
+      error.printErrorStack();
+      return false;
+  }
+
+  return true;
+}
+
 
 bool HDF5Tool::write_dataset_double_rank_2(std::string name, std::string groupname, std::vector<std::vector<double>> data)
 {
@@ -435,59 +588,60 @@ bool HDF5Tool::write_dataset_double_rank_2(std::string name, std::string groupna
   return true;
 }
 
-bool HDF5Tool::write_dataset_double_rank_3(std::string name, std::string groupname, std::vector<std::vector<std::vector<double>>> data)
+bool HDF5Tool::read_dataset_string_rank_1(std::string name, std::string groupname, std::vector<std::string> &data)
 {
+  std::string log = "";
+
   // Try block to detect exceptions raised by any of the calls inside it
   try {
-    const int rank = 3;
-    if (data.size()==0)
+    const int rank = 1;
+    if (data.size()!=0)
     {
-      return true;
+      log = "data not empty -> please write an issue on github\n";
+      PRINT_INFO("%s", log.c_str());
+      return false;
     }
-    if (data[0].size()==0)
-    {
-      return true;
-    }
-    if (data[0][0].size()==0)
-    {
-      return true;
-    }
+
     // Turn off the auto-printing when failure occurs so that we can
     // handle the errors appropriately
     H5::Exception::dontPrint();
 
-    H5::Group group(this->file->openGroup(groupname.c_str()));
-    hsize_t dims[rank]; // dataset dimensions
-    dims[0]              = data.size();
-    dims[1]              = data[0].size();
-    dims[2]              = data[0][0].size();
-    H5::DataSpace *dataspace = new H5::DataSpace(rank, dims);
-    
-    H5::DataSet *dataset = new H5::DataSet(group.createDataSet(name.c_str(), H5::PredType::NATIVE_DOUBLE, *dataspace));
-
-    // Write the data to the dataset using default memory space, file
-    // space, and transfer properties.
-    
-    double *wdata = new double[dims[0]*dims[1]*dims[2]]; // buffer for data to write
-    
-    for (size_t i = 0; i < data.size(); i++)
+    H5::Group group(file->openGroup(groupname.c_str()));
+    if (!group.exists(name.c_str()))
     {
-      for (size_t ii = 0; ii < data[i].size(); ii++)
-      {
-        for (size_t iii = 0; iii < data[i][ii].size(); iii++)
-        {
-          wdata[dims[1]*dims[2]*i + dims[2]*ii + iii] = data[i][ii][iii];
-        }
-      }
+      //log = "dataset " + name + " in group " + groupname + " doesn't exist\n";
+      //PRINT_INFO("%s", log.c_str());
+      return false;
     }
-    dataset->write(wdata, H5::PredType::NATIVE_DOUBLE);
-        
-    // Close all objects.
-    delete dataspace;
-    delete dataset;
-    delete wdata;
-    group.close();
+    
+    H5::DataSet dataset = group.openDataSet(name);
+    H5::DataSpace dataspace = dataset.getSpace();
+    const int ndims = dataspace.getSimpleExtentNdims();
 
+    if (rank!=ndims)
+    {
+      log = "ranks doesn't match in dataset " + name + " in group " + groupname + "\n";
+      PRINT_INFO("%s", log.c_str());
+      return false;
+    }
+    
+    hsize_t dims[rank];
+    dataspace.getSimpleExtentDims( dims, NULL);
+    H5::StrType datatype(H5::PredType::C_S1, H5T_VARIABLE); 
+
+    std::vector<const char *> rdata(dims[0]); // buffer for data to read
+
+    dataset.read(rdata.data(), datatype);
+        
+    for (size_t i = 0; i < dims[0]; i++)
+    { 
+      data.push_back(rdata[i]);
+    }
+    
+    // Close all objects.
+    dataspace.close();
+    dataset.close();
+    group.close();
     return true;
   } // end of try block
 
@@ -505,7 +659,6 @@ bool HDF5Tool::write_dataset_double_rank_3(std::string name, std::string groupna
 
   return true;
 }
-
 
 bool HDF5Tool::read_dataset_string_rank_2(std::string name, std::string groupname, std::vector<std::vector<std::string>> &data)
 {
@@ -551,18 +704,6 @@ bool HDF5Tool::read_dataset_string_rank_2(std::string name, std::string groupnam
     std::vector<const char *> rdata(dims[0]*dims[1]); // buffer for data to read
 
     dataset.read(rdata.data(), datatype);
-
-    /*
-    int getArrayLength = rdata.size();
-    std::string log = "array length " + std::to_string(getArrayLength) + " dims[0] " + std::to_string(dims[0]) + " dims[1] " + std::to_string(dims[1]) + "\n";
-    PRINT_INFO("%s", log.c_str());
-
-    for (size_t i = 0; i < rdata.size(); i++)
-    {
-      log = "i " + std::to_string(i) + " rdata[i] " + rdata[i] + "\n";
-      PRINT_INFO("%s", log.c_str());
-    }
-    */
         
     for (size_t i = 0; i < dims[0]; i++)
     { 

--- a/src/Utility/HDF5Tool.hpp
+++ b/src/Utility/HDF5Tool.hpp
@@ -20,10 +20,15 @@ public:
   bool read_dataset_int_rank_2(std::string name, std::string groupname, std::vector<std::vector<int>> &data); // read dataset
   bool write_dataset_int_rank_1(std::string name, std::string groupname, std::vector<int> data); // create dataset
   bool write_dataset_int_rank_2(std::string name, std::string groupname, std::vector<std::vector<int>> data); // create dataset
+  bool write_dataset_int_rank_3(std::string name, std::string groupname, std::vector<std::vector<std::vector<int>>> data); // create dataset
   //double
+  bool write_dataset_double_rank_1(std::string name, std::string groupname, std::vector<double> data); // create dataset
+  bool write_dataset_double_rank_2(std::string name, std::string groupname, std::vector<std::vector<double>> data); // create dataset
+  bool write_dataset_double_rank_3(std::string name, std::string groupname, std::vector<std::vector<std::vector<double>>> data); // create dataset
 
   //string
   bool read_dataset_string_rank_2(std::string name, std::string groupname, std::vector<std::vector<std::string>> &data); // read dataset
+  bool write_dataset_string_rank_1(std::string name, std::string groupname, std::vector<std::string> data); // create dataset
   bool write_dataset_string_rank_2(std::string name, std::string groupname, std::vector<std::vector<std::string>> data); // create dataset
 
   H5::H5File *file;

--- a/src/Utility/HDF5Tool.hpp
+++ b/src/Utility/HDF5Tool.hpp
@@ -17,16 +17,18 @@ public:
   bool createGroup(std::string groupname);
 
   //int
+  bool read_dataset_int_rank_1(std::string name, std::string groupname, std::vector<int> &data); // read dataset
   bool read_dataset_int_rank_2(std::string name, std::string groupname, std::vector<std::vector<int>> &data); // read dataset
   bool write_dataset_int_rank_1(std::string name, std::string groupname, std::vector<int> data); // create dataset
   bool write_dataset_int_rank_2(std::string name, std::string groupname, std::vector<std::vector<int>> data); // create dataset
-  bool write_dataset_int_rank_3(std::string name, std::string groupname, std::vector<std::vector<std::vector<int>>> data); // create dataset
   //double
+  bool read_dataset_double_rank_1(std::string name, std::string groupname, std::vector<double> &data); // read dataset
+  bool read_dataset_double_rank_2(std::string name, std::string groupname, std::vector<std::vector<double>> &data); // read dataset
   bool write_dataset_double_rank_1(std::string name, std::string groupname, std::vector<double> data); // create dataset
   bool write_dataset_double_rank_2(std::string name, std::string groupname, std::vector<std::vector<double>> data); // create dataset
-  bool write_dataset_double_rank_3(std::string name, std::string groupname, std::vector<std::vector<std::vector<double>>> data); // create dataset
-
+  
   //string
+  bool read_dataset_string_rank_1(std::string name, std::string groupname, std::vector<std::string> &data); // read dataset
   bool read_dataset_string_rank_2(std::string name, std::string groupname, std::vector<std::vector<std::string>> &data); // read dataset
   bool write_dataset_string_rank_1(std::string name, std::string groupname, std::vector<std::string> data); // create dataset
   bool write_dataset_string_rank_2(std::string name, std::string groupname, std::vector<std::vector<std::string>> data); // create dataset


### PR DESCRIPTION
Fixes issue #23
There was a non threadsafe code in the dat link part.

Adds the user option to safe the loaded results from the core to the safe file.
The loaded frd and dat results can now be saved and loaded from the .cub5
So a conversion to paraview or the frd and dat tab can now be used after opening a .cub5 without loading the .frd or .dat again.